### PR TITLE
feat(gatsby-theme): added next and prev markers

### DIFF
--- a/packages/gatsby-theme-availity/src/components/PageContent/PageNav.js
+++ b/packages/gatsby-theme-availity/src/components/PageContent/PageNav.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MdChevronLeft, MdChevronRight } from 'react-icons/md';
+import { NavLink } from 'reactstrap';
+import { Link } from 'gatsby';
+
+const PageNav = ({ nextPage, prevPage }) => (
+  <div className="d-flex justify-content-between mt-5 mb-5">
+    {prevPage && (
+      <NavLink
+        tag={Link}
+        to={prevPage.path}
+        className="d-flex align-items-center text-secondary"
+      >
+        <MdChevronLeft size={25} className="mr-3" />
+        <span>
+          <small>PREVIOUS</small>
+          <br />
+          <b>{prevPage.title}</b>
+        </span>
+      </NavLink>
+    )}
+    {nextPage && (
+      <NavLink
+        tag={Link}
+        to={nextPage.path}
+        className="d-flex align-items-center text-secondary ml-auto"
+      >
+        <span className="text-right">
+          <small>NEXT</small>
+          <br />
+          <b>{nextPage.title}</b>
+        </span>
+        <MdChevronRight size={25} className="ml-3" />
+      </NavLink>
+    )}
+  </div>
+);
+
+PageNav.propTypes = {
+  nextPage: PropTypes.object,
+  prevPage: PropTypes.object,
+};
+
+export default PageNav;

--- a/packages/gatsby-theme-availity/src/components/PageContent/index.js
+++ b/packages/gatsby-theme-availity/src/components/PageContent/index.js
@@ -1,7 +1,16 @@
 import React, { useRef, useEffect } from 'react';
+import PageNav from './PageNav';
 import SectionNav from './SectionNav';
 
-const PageContent = ({ children, headings, mainRef, title, ...props }) => {
+const PageContent = ({
+  children,
+  headings,
+  mainRef,
+  title,
+  pageIndex,
+  pages,
+  ...props
+}) => {
   const contentRef = useRef();
 
   useEffect(() => {
@@ -29,6 +38,10 @@ const PageContent = ({ children, headings, mainRef, title, ...props }) => {
         ref={contentRef}
       >
         {children}
+        <PageNav
+          prevPage={pages[pageIndex - 1]}
+          nextPage={pages[pageIndex + 1]}
+        />
       </div>
       <SectionNav
         headings={headings}

--- a/packages/gatsby-theme-availity/src/index.js
+++ b/packages/gatsby-theme-availity/src/index.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { graphql } from 'gatsby';
+import { graphql, withPrefix } from 'gatsby';
 import RehypeReact from 'rehype-react';
 import { Table } from 'reactstrap';
 import { MDXProvider } from '@mdx-js/react';
@@ -50,6 +50,13 @@ const Template = ({
     return !location.pathname.indexOf(value);
   }
 
+  const pageIndex = pages.findIndex(page => {
+    const prefixedPath = withPrefix(page.path);
+    return (
+      prefixedPath === pathname || prefixedPath.replace(/\/$/, '') === pathname
+    );
+  });
+
   return (
     <div className="h-100 d-flex flex-column">
       <SiteMetadata pathname={pathname} />
@@ -84,6 +91,7 @@ const Template = ({
             headings={headings}
             pages={pages}
             hash={hash}
+            pageIndex={pageIndex}
             mainRef={mainRef}
           >
             {file.childMdx ? (


### PR DESCRIPTION
We now have next and previous markers for seamlessly going through each section of the docs.

