### PR TITLE
feat(gatsby-theme-docs): added dynamic scopes support

### DIFF
--- a/packages/gatsby-theme-docs/src/components/CodeBlock/LiveCode.js
+++ b/packages/gatsby-theme-docs/src/components/CodeBlock/LiveCode.js
@@ -1,14 +1,31 @@
 // src/components/CodeBlock.js
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Reactstrap from 'reactstrap';
 import githubTheme from 'prism-react-renderer/themes/github';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import CopyClipboard from './CopyClipboard';
+import LiveCodeScopes from '../LiveCodeScopes';
 
 const LiveCode = ({ children: code, hideCopy }) => (
   <div style={{ marginTop: '40px' }}>
-    <LiveProvider code={code} scope={{ ...Reactstrap }} mountStylesheet={false}>
+    <LiveProvider
+      code={code}
+      scope={{ ...LiveCodeScopes }}
+      mountStylesheet={false}
+      transformCode={code => {
+        console.log(
+          'Code',
+          code
+            .split('\n')
+            .filter(code => !code.startsWith('import'))
+            .join('\n')
+        );
+        return code
+          .split('\n')
+          .filter(code => !code.startsWith('import'))
+          .join('\n');
+      }}
+    >
       <LivePreview
         className="p-3 border border-bottom-0"
         style={{ borderTopRightRadius: 4, borderTopLeftRadius: 4 }}

--- a/packages/gatsby-theme-docs/src/components/LiveCodeScopes.js
+++ b/packages/gatsby-theme-docs/src/components/LiveCodeScopes.js
@@ -1,0 +1,7 @@
+import * as Reactstrap from 'reactstrap';
+
+const scopes = {
+  ...Reactstrap,
+};
+
+export default scopes;

--- a/packages/gatsby-theme-docs/src/index.js
+++ b/packages/gatsby-theme-docs/src/index.js
@@ -17,30 +17,30 @@ import {
 } from './components';
 import './styles.scss';
 
-const components = {
-  code: CodeBlock,
-  pre: props => props.children,
-  table: Table,
-  h2: ({ className, ...props }) => (
-    <h2 className={classnames(className, 'mt-5')} {...props} />
-  ),
-  h3: ({ className, ...props }) => (
-    <h3 className={classnames(className, 'mt-4')} {...props} />
-  ),
-};
-
-// Will take in a snippet of code in AST Form and render it as text
-const renderAst = new RehypeReact({
-  createElement: React.createElement,
-  components,
-}).Compiler;
-
 // The Template to load on each page
 const Template = ({
   location,
   pageContext: { sidebarContents, navItems, githubUrl },
   data,
 }) => {
+  const components = {
+    code: CodeBlock,
+    pre: props => props.children,
+    table: Table,
+    h2: ({ className, ...props }) => (
+      <h2 className={classnames(className, 'mt-5')} {...props} />
+    ),
+    h3: ({ className, ...props }) => (
+      <h3 className={classnames(className, 'mt-4')} {...props} />
+    ),
+  };
+
+  // Will take in a snippet of code in AST Form and render it as text
+  const renderAst = new RehypeReact({
+    createElement: React.createElement,
+    components,
+  }).Compiler;
+
   // Keep a ref of the current content window for jumping to certain anchors in section nav
   const mainRef = useRef(null);
 

--- a/packages/site/source/essentials/code-blocks.md
+++ b/packages/site/source/essentials/code-blocks.md
@@ -23,6 +23,77 @@ The below code block will not have a copy button because we passed `hideCopy` to
 ```
 ````
 
+## Live Preview
+
+You can enable the live preview by setting the `live` attribute to `true` for the codeblock. By default, your components being rendered will not be resolved because live preview doesn't babelify the `imports` you have in the codeblock. Instead it is provided via `scopes`. By default we include the whole `reactstrap` library so you can get started seeing what its like to write code blocks with reactstrap.
+
+### Reactstrap Live
+
+```jsx live=true
+<Container className="d-flex flex-column justify-content-center align-items-center">
+  <div className="lead">Check me Out!</div>
+  <Button color="primary">Click Me</Button>
+</Container>
+```
+
+### Custom Components
+
+In order to live preview your own components you will be taking advantage of [Component Shadowing](https://www.gatsbyjs.org/blog/2019-04-29-component-shadowing/). Please read the article for information on what this is before continuing.
+
+<br />
+
+We will be overriding the `LiveCodeScopes.js` component located at:  
+`@availity/gatsby-theme-docs/src/components/LiveCodeScopes.js`.
+
+This means your overrides folder structure will look like:
+
+```something hideCopy=true
+your-docs-site
+└── src
+    └── @availity
+        └── gatsby-theme-docs
+            └── components
+                └── LiveCodeScopes.js
+```
+
+You will need to export all of the components you want the `react-live` provider to be passed in the scopes.
+
+#### Example
+
+```jsx header=LiveCodeScopes.js
+import AppIcon from '@availity/app-icon';
+import * as Reactstrap from 'reactstrap';
+
+const scopes = {
+  ...Reactstrap,
+  AppIcon,
+};
+
+export default AppIcon;
+```
+
+Now render your code block below with `live=true`.
+
+```jsx live=true
+import AppIcon from '@availity/app-icon';
+
+<div className="w-100 d-flex flex-row justify-content-around align-items-center">
+  <AppIcon title="Payer Space" color="blue" branded size="xl">
+    PS
+  </AppIcon>
+  <AppIcon title="Payer Space" color="red" size="xl">
+    PS
+  </AppIcon>
+  <AppIcon title="Payer Space" color="orange">
+    PS
+  </AppIcon>
+</div>;
+```
+
+<br />
+
+Note that we ignore compiling the `import` statement so that at minimum the reader can see how the import works.
+
 <br />
 
 ## Configurations

--- a/packages/site/source/essentials/react.mdx
+++ b/packages/site/source/essentials/react.mdx
@@ -50,21 +50,7 @@ module.exports = {
 
 ### Usage
 
-import AppIcon from '@availity/app-icon';
-
-<div className="w-100 d-flex flex-row justify-content-around align-items-center">
-  <AppIcon title="Payer Space" color="blue" branded size="xl">
-    PS
-  </AppIcon>
-  <AppIcon title="Payer Space" color="red" size="xl">
-    PS
-  </AppIcon>
-  <AppIcon title="Payer Space" color="orange">
-    PS
-  </AppIcon>
-</div>
-
-```jsx
+```jsx live=true
 import AppIcon from '@availity/app-icon';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">

--- a/packages/site/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
+++ b/packages/site/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
@@ -1,0 +1,9 @@
+import * as Reactstrap from 'reactstrap';
+import AppIcon from '@availity/app-icon';
+
+const scopes = {
+  ...Reactstrap,
+  AppIcon,
+};
+
+export default scopes;


### PR DESCRIPTION
You now can render your own custom components in the live preview via component shadowing.