### PR TITLE
refactor(gatsby-theme-docs): ability to include relative a tag link

### DIFF
--- a/packages/gatsby-theme-docs/src/components/SideNav/NavLink.js
+++ b/packages/gatsby-theme-docs/src/components/SideNav/NavLink.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 import { Nav, Collapse, NavItem, NavLink as RsNavLink } from 'reactstrap';
-import { isAbsoluteUrl } from '@availity/resolve-url';
 // eslint-disable-next-line import/no-cycle
 import NavigationItem from './NavItem';
 
@@ -15,53 +14,59 @@ const NavLink = ({
   pages,
 }) => (
   <Nav vertical tag={isRootLink ? 'ul' : Collapse} {...collapseProps} navbar>
-    {pages.map(({ path, title, pages: subPages, anchor }) => {
-      const isAbsolutePath = anchor && isAbsoluteUrl(path);
+    {pages.map(
+      ({
+        path,
+        title,
+        pages: subPages,
+        isRelative = true,
+        withPrefix: _withPrefix = false,
+      }) => {
+        const linkProps = {
+          tag: isRelative ? Link : 'a',
+        };
 
-      const linkProps = {
-        tag: isAbsolutePath ? 'a' : Link,
-      };
+        if (isRelative) {
+          linkProps.to = path;
+        } else {
+          linkProps.href = _withPrefix ? withPrefix(path) : path;
+        }
 
-      if (isAbsolutePath) {
-        linkProps.href = path;
-      } else {
-        linkProps.to = path;
-      }
-
-      return subPages && !isSecondaryCategory ? (
-        <NavigationItem
-          key={title}
-          collapseTitle={title}
-          isCategorySelected={isPageSelected({
-            path,
-            pages: [...subPages, { title, path }],
-          })}
-          pages={subPages}
-          path={path}
-          isPageSelected={isPageSelected}
-        />
-      ) : (
-        <NavItem
-          key={title}
-          active={isPageSelected({ path })}
-          className="position-relative d-flex align-items-center"
-        >
-          <RsNavLink
-            {...linkProps}
-            active={isPageSelected({ path })}
-            className={classnames('py-2 w-100', {
-              'pl-4': !isSecondaryCategory,
-              'pl-5': isSecondaryCategory,
-              'sidenav-link-active hover': isPageSelected({ path }),
-              'text-secondary sidenav-link hover': !isPageSelected({ path }),
-              'sidenav-link-secondary': isSecondaryCategory,
+        return subPages && !isSecondaryCategory ? (
+          <NavigationItem
+            key={title}
+            collapseTitle={title}
+            isCategorySelected={isPageSelected({
+              path,
+              pages: [...subPages, { title, path }],
             })}
+            pages={subPages}
+            path={path}
+            isPageSelected={isPageSelected}
+          />
+        ) : (
+          <NavItem
+            key={title}
+            active={isPageSelected({ path })}
+            className="position-relative d-flex align-items-center"
           >
-            {title}
-          </RsNavLink>
-        </NavItem>
-      );
-    })}
+            <RsNavLink
+              {...linkProps}
+              active={isPageSelected({ path })}
+              className={classnames('py-2 w-100', {
+                'pl-4': !isSecondaryCategory,
+                'pl-5': isSecondaryCategory,
+                'sidenav-link-active hover': isPageSelected({ path }),
+                'text-secondary sidenav-link hover': !isPageSelected({ path }),
+                'sidenav-link-secondary': isSecondaryCategory,
+              })}
+            >
+              {title}
+            </RsNavLink>
+          </NavItem>
+        );
+      }
+    )}
   </Nav>
 );
 


### PR DESCRIPTION
Adds ability to have relative links in the side nav that are not using `Link` from gatsby.

Use Case:

Availity React deploys both `storybook` and `docs` to the same folder. However, if we just included a relative link to `storybook` in the sidebar contents for `docs` it would show the page as not found. This is because the `Link` tag in gatsby tries to find the page that was created and hot swap it on the DOM rather than refreshing the whole page. The relative link to storybook is the correct path but needs to be an anchor tag in order for it to have proper refreshing