### PR TITLE
refactor(gatsby-theme-docs): moved formik and api resource to peer deps

### DIFF
--- a/docs/source/reference/gatsby-docs.md
+++ b/docs/source/reference/gatsby-docs.md
@@ -4,6 +4,10 @@ title: Gatsby Theme Docs
 
 This API Reference documents all the available configurations for `gatsby-config.js`.
 
+```bash
+npX install-peerdeps @availity/gatsby-theme-docs
+```
+
 ## Default Theme Options
 
 We include an export for the default theme options in the case you don't want to explicity put them there yourself.

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -29,29 +29,35 @@
     "gatsby": "^2.13.83",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "reactstrap": "^8.0.1"
+    "reactstrap": "^8.0.1",
+    "formik": "2.0.1-rc.12",
+    "@availity/spaces": "^3.1.0",
+    "@availity/api-axios": "^5.4.0",
+    "@availity/api-core": "^5.4.0",
+    "@availity/localstorage-core": "^2.6.1",
+    "axios": "^0.19.0"
   },
   "devDependencies": {
     "gatsby": "^2.13.83",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "reactstrap": "^8.0.1"
-  },
-  "dependencies": {
+    "reactstrap": "^8.0.1",
+    "formik": "2.0.1-rc.12",
+    "@availity/spaces": "^3.1.0",
     "@availity/api-axios": "^5.4.0",
     "@availity/api-core": "^5.4.0",
-    "@availity/gatsby-theme-core": "^2.0.0",
     "@availity/localstorage-core": "^2.6.1",
+    "axios": "^0.19.0"
+  },
+  "dependencies": {
+    "@availity/gatsby-theme-core": "^2.0.0",
     "@availity/page-header": "^8.0.2",
     "@availity/resolve-url": "^1.1.0",
-    "@availity/spaces": "^3.1.0",
     "@loadable/component": "^5.10.2",
     "@mdx-js/mdx": "^1.3.1",
     "@mdx-js/react": "^1.3.1",
     "availity-uikit": "^3.2.0",
-    "axios": "^0.19.0",
     "classnames": "^2.2.6",
-    "formik": "2.0.1-rc.12",
     "gatsby-plugin-compile-es6-packages": "^2.1.0",
     "gatsby-plugin-mdx": "^1.0.24",
     "gatsby-remark-autolink-headers": "^2.1.4",


### PR DESCRIPTION
BREAKING CHANGE: axios, formik, @availity/api-core @availity/api-axios and @availity/localstorage-core are not peer deps

closes #22 