### PR TITLE
fix(gatsby-theme-docs): fix flex items getting squished in safari

### DIFF
--- a/packages/gatsby-theme-core/src/components/TopNav/index.js
+++ b/packages/gatsby-theme-core/src/components/TopNav/index.js
@@ -29,7 +29,7 @@ const Navigation = ({
     <Navbar
       light
       expand="md"
-      className={classnames('bg-light flex-md-nowrap', className)}
+      className={classnames('bg-light flex-md-nowrap flex-shrink-0', className)}
       {...props}
     >
       <NavbarBrand

--- a/packages/gatsby-theme-docs/src/components/PageContent/PageHeader.js
+++ b/packages/gatsby-theme-docs/src/components/PageContent/PageHeader.js
@@ -62,6 +62,7 @@ const CustomPageHeader = ({
 
   return (
     <PageHeader
+      className="flex-shrink-0"
       homeUrl="/"
       appName={isIndexPage ? siteTitle : title}
       crumbs={isIndexPage ? [] : crumbs}

--- a/packages/gatsby-theme-docs/src/components/PageContent/index.js
+++ b/packages/gatsby-theme-docs/src/components/PageContent/index.js
@@ -35,7 +35,7 @@ const PageContent = ({
   }, []);
 
   return (
-    <div className="d-flex align-items-start">
+    <div className="d-flex align-items-start flex-shrink-0">
       <div
         className="flex-grow-1 content-wrapper"
         style={{ width: 0, maxWidth: '110ch' }}

--- a/packages/gatsby-theme-docs/src/components/SideNav/index.js
+++ b/packages/gatsby-theme-docs/src/components/SideNav/index.js
@@ -27,7 +27,7 @@ const SideNav = ({ currentPath, contents, siteTitle, ...rest }) => {
 
   return (
     <div {...rest}>
-      <Nav vertical navbar className="h-100 text-dark">
+      <Nav vertical navbar className="text-dark">
         <CollapseProvider siteName={siteTitle}>
           {contents.map(
             ({ title: collapseTitle, pages, path: categoryPath, depth }) => (

--- a/packages/gatsby-theme-docs/src/index.js
+++ b/packages/gatsby-theme-docs/src/index.js
@@ -85,7 +85,7 @@ const Template = ({
         navItems={navItems}
         pathname={pathname}
       />
-      <div className="d-flex h-100">
+      <div className="d-flex overflow-hidden">
         <SideNavigation
           currentPath={pathname}
           contents={sidebarContents}
@@ -97,7 +97,7 @@ const Template = ({
           }}
         />
         <div
-          className="d-flex flex-column h-100 w-100 px-5 pb-5 pt-4"
+          className="d-flex flex-column w-100 px-5 pb-5 pt-4"
           style={{
             overflowY: 'auto',
           }}


### PR DESCRIPTION
Fixes issue where flex items where getting squished in Safari. Avoids using percentage heights on flex items.

Fixes #20 